### PR TITLE
Support "unix" (socket) and other kinds of "net.Dial" networks

### DIFF
--- a/cmd/mpd-mpris/main.go
+++ b/cmd/mpd-mpris/main.go
@@ -12,6 +12,7 @@ import (
 )
 
 var (
+	network  string
 	addr     string
 	port     int
 	password string
@@ -20,6 +21,7 @@ var (
 )
 
 func init() {
+	flag.StringVar(&network, "network", "tcp", "The network used to dial to the mpd server. Check https://golang.org/pkg/net/#Dial for available values (most common are tcp and unix). Default value is \"tcp\"")
 	flag.StringVar(&addr, "host", "", "The MPD host (default localhost)")
 	flag.IntVar(&port, "port", 6600, "The MPD port")
 	flag.StringVar(&password, "pwd", "", "The MPD connection password. Leave empty for none.")
@@ -52,10 +54,19 @@ func main() {
 		err error
 	)
 
-	if password == "" {
-		c, err = mpd.Dial("tcp", fmt.Sprintf("%s:%d", addr, port))
+	// Parse the full address
+	// If network is tcp, then we would ideally want a port attached. Else we juts take "addr"
+	var fullAddress string
+	if network == "tcp" {
+		fullAddress = fmt.Sprintf("%s:%d", addr, port)
 	} else {
-		c, err = mpd.DialAuthenticated("tcp", fmt.Sprintf("%s:%d", addr, port), password)
+		fullAddress = addr
+	}
+
+	if password == "" {
+		c, err = mpd.Dial(network, fullAddress)
+	} else {
+		c, err = mpd.DialAuthenticated(network, fullAddress, password)
 	}
 
 	if err != nil {

--- a/cmd/mpd-mpris/main.go
+++ b/cmd/mpd-mpris/main.go
@@ -21,9 +21,9 @@ var (
 )
 
 func init() {
-	flag.StringVar(&network, "network", "tcp", "The network used to dial to the mpd server. Check https://golang.org/pkg/net/#Dial for available values (most common are tcp and unix). Default value is \"tcp\"")
+	flag.StringVar(&network, "network", "tcp", "The network used to dial to the mpd server. Check https://golang.org/pkg/net/#Dial for available values (most common are \"tcp\" and \"unix\")")
 	flag.StringVar(&addr, "host", "", "The MPD host (default localhost)")
-	flag.IntVar(&port, "port", 6600, "The MPD port")
+	flag.IntVar(&port, "port", 6600, "The MPD port. Only works if network is \"tcp\". If you use anything else, you should put the port inside addr yourself.")
 	flag.StringVar(&password, "pwd", "", "The MPD connection password. Leave empty for none.")
 	flag.BoolVar(&noInstance, "no-instance", false, "Set the MPDris's interface as 'org.mpris.MediaPlayer2.mpd' instead of 'org.mpris.MediaPlayer2.mpd.instance#'")
 }


### PR DESCRIPTION
Fixes #7.

Adds the following flag:
 - `-network`: set the network type, according to `https://golang.org/pkg/net/#Dial`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/natsukagami/mpd-mpris/8)
<!-- Reviewable:end -->
