### PR TITLE
Push xesam:url metadata

### DIFF
--- a/tracklist.go
+++ b/tracklist.go
@@ -62,6 +62,7 @@ func MapFromSong(s mpd.Song) MetadataMap {
 
 	m.nonEmptyString("xesam:album", s.Album)
 	m.nonEmptyString("xesam:title", s.Title)
+	m.nonEmptyString("xesam:url", s.Path())
 	m.nonEmptyString("xesam:contentCreated", s.Date)
 	m.nonEmptySlice("xesam:albumArtist", []string{s.AlbumArtist})
 	m.nonEmptySlice("xesam:artist", []string{s.Artist})


### PR DESCRIPTION
Fixes #9.

Uses `mpd`'s "file" field value. It is relative to the root of the library (I think).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/natsukagami/mpd-mpris/10)
<!-- Reviewable:end -->
