### PR TITLE
Fix rounding error when setting mpd's volume

### DIFF
--- a/player.go
+++ b/player.go
@@ -200,7 +200,7 @@ func (p *Player) OnLoopStatus(c *prop.Change) *dbus.Error {
 
 // OnVolume handles volume changes.
 func (p *Player) OnVolume(c *prop.Change) *dbus.Error {
-	val := int(c.Value.(float64) * 100)
+	val := int(math.Round(c.Value.(float64) * 100))
 	log.Printf("Volume changed to %v\n", val)
 	p.status.mu.Lock()
 	defer p.status.mu.Unlock()


### PR DESCRIPTION
When trying to set mpd's volume to 58%, we would multiply 0.58 * 100, which would return 57.99999999999999. Then, we would cast it to an integer, which would give us 57 instead of 58.

The joys of floating point arithmetic!

Fixes #18

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/natsukagami/mpd-mpris/20)
<!-- Reviewable:end -->
