### PR TITLE
Allow the user to configure the position update interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,15 @@ Install scripts coming soon.
 # mpd-mpris --help
 Usage of mpd-mpris:
   -host string
-        The MPD host. (default "localhost")
+        The MPD host (default localhost)
+  -interval duration
+        How often to update the current song position. Set to 0 to never update the current song position. (default 1s)
+  -network string
+        The network used to dial to the mpd server. Check https://golang.org/pkg/net/#Dial for available values (most common are "tcp" and "unix") (default "tcp")
   -no-instance
         Set the MPDris's interface as 'org.mpris.MediaPlayer2.mpd' instead of 'org.mpris.MediaPlayer2.mpd.instance#'
   -port int
-        The MPD port (default 6600)
+        The MPD port. Only works if network is "tcp". If you use anything else, you should put the port inside addr yourself. (default 6600)
   -pwd string
         The MPD connection password. Leave empty for none.
 ```

--- a/cmd/mpd-mpris/main.go
+++ b/cmd/mpd-mpris/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	mpris "github.com/natsukagami/mpd-mpris"
 	"github.com/natsukagami/mpd-mpris/mpd"
@@ -19,6 +20,7 @@ var (
 	password string
 
 	noInstance bool
+	interval   time.Duration
 )
 
 func init() {
@@ -27,6 +29,7 @@ func init() {
 	flag.IntVar(&port, "port", 6600, "The MPD port. Only works if network is \"tcp\". If you use anything else, you should put the port inside addr yourself.")
 	flag.StringVar(&password, "pwd", "", "The MPD connection password. Leave empty for none.")
 	flag.BoolVar(&noInstance, "no-instance", false, "Set the MPDris's interface as 'org.mpris.MediaPlayer2.mpd' instead of 'org.mpris.MediaPlayer2.mpd.instance#'")
+	flag.DurationVar(&interval, "interval", time.Second, "How often to update the current song position. Set to 0 to never update the current song position.")
 }
 
 func detectLocalSocket() {
@@ -93,7 +96,7 @@ func main() {
 		opts = append(opts, mpris.NoInstance())
 	}
 
-	instance, err := mpris.NewInstance(c, opts...)
+	instance, err := mpris.NewInstance(c, interval, opts...)
 
 	if err != nil {
 		panic(err)

--- a/instance.go
+++ b/instance.go
@@ -3,6 +3,7 @@ package mpris
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/godbus/dbus/v5/introspect"
 
@@ -33,7 +34,7 @@ func (ins *Instance) Name() string {
 }
 
 // NewInstance creates a new instance that takes care of the specified mpd.
-func NewInstance(mpd *mpd.Client, opts ...Option) (ins *Instance, err error) {
+func NewInstance(mpd *mpd.Client, interval time.Duration, opts ...Option) (ins *Instance, err error) {
 	ins = &Instance{
 		mpd: mpd,
 
@@ -52,7 +53,7 @@ func NewInstance(mpd *mpd.Client, opts ...Option) (ins *Instance, err error) {
 	ins.dbus.Export(mp2, "/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2")
 
 	player := &Player{Instance: ins}
-	player.createStatus()
+	player.createStatus(interval)
 	ins.dbus.Export(player, "/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.Player")
 
 	ins.dbus.Export(introspect.NewIntrospectable(ins.IntrospectNode()), "/org/mpris/MediaPlayer2", "org.freedesktop.DBus.Introspectable")

--- a/player.go
+++ b/player.go
@@ -221,7 +221,7 @@ func (p *Player) OnShuffle(c *prop.Change) *dbus.Error {
 	return p.transformErr(p.mpd.Random(c.Value.(bool)))
 }
 
-func (p *Player) createStatus() {
+func (p *Player) createStatus(interval time.Duration) {
 	status, err := p.mpd.Status()
 	if err != nil {
 		log.Fatalf("%+v", err)
@@ -261,15 +261,17 @@ func (p *Player) createStatus() {
 	}
 
 	// Set up a position updater
-	go func() {
-		tick := time.NewTicker(time.Second / 10)
-		defer tick.Stop()
-		for range tick.C {
-			if err := p.status.Update(p); err != nil {
-				log.Printf("%+v\n", err)
+	if interval > 0 {
+		go func() {
+			tick := time.NewTicker(interval)
+			defer tick.Stop()
+			for range tick.C {
+				if err := p.status.Update(p); err != nil {
+					log.Printf("%+v\n", err)
+				}
 			}
-		}
-	}()
+		}()
+	}
 
 	p.props = map[string]*prop.Prop{
 		"PlaybackStatus": newProp(playStatus, nil),


### PR DESCRIPTION
After I started using mpd-mpris on my laptop I noticed significantly
more wakeups than before even when mpd is not playing anything. This
seemed surprising, because applications using dbus typically do not
require polling.

Looking more closely, the polling comes from updating the current song
position, since this doesn't generate dbus events. As such, this also
happens even when mpd is idle.

The interval is now configurable, and if set to 0, never updates the
status just for position information (although, of course, it will be
updated on other changes that result in a status update).

On my machine, this renders mpd-mpris significantly more willing to
sleep and avoid wakeups, especially since I don't use this feature
anyway, so it's nice to be able to disable it with `--interval 0`.