### PR TITLE
Passively wait for mpd to send events for updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Per-instance configurations:
 - `services.mpd-mpris.instances.{name}.network`: The network type. (`-network` flag)
 - `services.mpd-mpris.instances.{name}.port`: The port to connect to. (`-port` flag)
 - `services.mpd-mpris.instances.{name}.passwordFile`: The file containing the password to use. (`-pwd-file` flag)
-- `services.mpd-mpris.instances.{name}.interval`: The update interval. (`-interval` flag)
 
 Each instance will create a `mpd-mpris-{name}` service (with the default being `mpd-mpris`), with the MPRIS instance name
 `org.mpris.MediaPlayer2.mpd.{name}` (with the default being just `org.mpris.MediaPlayer2.mpd`).
@@ -81,8 +80,6 @@ Usage of mpd-mpris:
         The MPD host (default localhost)
   -instance-name string
         Set the MPRIS's interface as 'org.mpris.MediaPlayer2.mpd.{instance-name}'
-  -interval duration
-        How often to update the current song position. Set to 0 to never update the current song position. (default 1s)
   -network string
         The network used to dial to the mpd server. Check https://golang.org/pkg/net/#Dial for available values (most common are "tcp" and "unix") (default "tcp")
   -no-instance

--- a/cmd/mpd-mpris/main.go
+++ b/cmd/mpd-mpris/main.go
@@ -119,7 +119,7 @@ func main() {
 	}
 
 	if err != nil {
-		panic(err)
+		log.Fatalf("Cannot connect to mpd: %+v", err)
 	}
 
 	opts := []mpris.Option{}
@@ -136,7 +136,7 @@ func main() {
 	instance, err := mpris.NewInstance(c, interval, opts...)
 
 	if err != nil {
-		panic(err)
+		log.Fatalf("Cannot create a MPRIS instance: %+v", err)
 	}
 	defer instance.Close()
 

--- a/cmd/mpd-mpris/main.go
+++ b/cmd/mpd-mpris/main.go
@@ -7,8 +7,10 @@ import (
 	"io"
 	"log"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strings"
+	"syscall"
 
 	mpris "github.com/natsukagami/mpd-mpris"
 	"github.com/natsukagami/mpd-mpris/mpd"
@@ -133,7 +135,7 @@ func main() {
 
 	// start everything!
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
 	instance, err := mpris.NewInstance(ctx, c, opts...)
@@ -145,10 +147,10 @@ func main() {
 
 	log.Println("mpd-mpris running")
 
-	<-make(chan int)
+	<-ctx.Done()
 
 	// shut everything down
-	cancel()
+	log.Println("mpd-mpris stopping")
 
 	if err := instance.Close(); err != nil {
 		log.Fatalf("Cannot shut down cleanly: %+v", err)

--- a/cmd/mpd-mpris/main.go
+++ b/cmd/mpd-mpris/main.go
@@ -138,7 +138,7 @@ func main() {
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 
-	instance, err := mpris.NewInstance(ctx, c, opts...)
+	instance, err := mpris.NewInstance(c, opts...)
 
 	if err != nil {
 		log.Fatalf("Cannot create a MPRIS instance: %+v", err)
@@ -147,10 +147,13 @@ func main() {
 
 	log.Println("mpd-mpris running")
 
-	<-ctx.Done()
+	if err := instance.Start(ctx); err != nil {
+		log.Printf("Error: %+v", err)
+	} else {
+		log.Println("mpd-mpris stopping")
+	}
 
 	// shut everything down
-	log.Println("mpd-mpris stopping")
 
 	if err := instance.Close(); err != nil {
 		log.Fatalf("Cannot shut down cleanly: %+v", err)

--- a/errors.go
+++ b/errors.go
@@ -1,7 +1,7 @@
 package mpris
 
 import (
-	"fmt"
+	"log"
 
 	"github.com/godbus/dbus/v5"
 	"github.com/pkg/errors"
@@ -14,7 +14,7 @@ func (ins *Instance) transformErr(err error) *dbus.Error {
 	}
 	// We have to blindly test the mpd connection here. Not a good choice, but meh...
 	if err := ins.mpd.Ping(); err != nil {
-		panic(fmt.Sprint("connection to mpd is severed: ", err))
+		log.Fatalln("connection to mpd is severed: ", err)
 	}
 	var dbusErr dbus.Error
 	if !errors.As(err, &dbusErr) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/natsukagami/mpd-mpris
 go 1.12
 
 require (
-	github.com/fhs/gompd/v2 v2.2.0
+	github.com/fhs/gompd/v2 v2.3.0
 	github.com/godbus/dbus/v5 v5.0.3
 	github.com/pkg/errors v0.9.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/fhs/gompd/v2 v2.2.0 h1:zdSYAAOzQ5cCCgYa5CoXkL0Vr0Cqb/b5JmTobirLc90=
-github.com/fhs/gompd/v2 v2.2.0/go.mod h1:nNdZtcpD5VpmzZbRl5rV6RhxeMmAWTxEsSIMBkmMIy4=
+github.com/fhs/gompd/v2 v2.3.0 h1:wuruUjmOODRlJhrYx73rJnzS7vTSXSU7pWmZtM3VPE0=
+github.com/fhs/gompd/v2 v2.3.0/go.mod h1:nNdZtcpD5VpmzZbRl5rV6RhxeMmAWTxEsSIMBkmMIy4=
 github.com/godbus/dbus/v5 v5.0.3 h1:ZqHaoEF7TBzh4jzPmqVhE/5A1z9of6orkAe5uHoAeME=
 github.com/godbus/dbus/v5 v5.0.3/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/instance.go
+++ b/instance.go
@@ -85,7 +85,8 @@ func (ins *Instance) Start(ctx context.Context) error {
 		return errors.WithStack(err)
 	}
 
-	// Set up a seek updater
+	// Set up a periodic updaters
+	go ins.mpd.Keepalive(ctx)
 	go ins.player.pollSeek(ctx)
 
 	// Set up a status updater

--- a/instance.go
+++ b/instance.go
@@ -25,10 +25,17 @@ type Instance struct {
 
 // Close ends the connection.
 func (ins *Instance) Close() error {
+	if ins.mpd == nil {
+		return nil // already closed
+	}
 	if err := ins.dbus.Close(); err != nil {
 		return errors.WithStack(err)
 	}
-	return ins.mpd.Close()
+	if err := ins.mpd.Close(); err != nil {
+		return err
+	}
+	ins.mpd = nil
+	return nil
 }
 
 // Name returns the name of the instance.

--- a/instance.go
+++ b/instance.go
@@ -85,6 +85,9 @@ func (ins *Instance) Start(ctx context.Context) error {
 		return errors.WithStack(err)
 	}
 
+	// Set up a seek updater
+	go ins.player.pollSeek(ctx)
+
 	// Set up a status updater
 	for {
 		if err := ins.mpd.Poll(ctx); errors.Is(err, context.Canceled) {

--- a/mpd/subscribe.go
+++ b/mpd/subscribe.go
@@ -1,0 +1,46 @@
+package mpd
+
+import (
+	"context"
+
+	"github.com/fhs/gompd/v2/mpd"
+	"github.com/pkg/errors"
+)
+
+// Watcher is our implementation of the watcher.
+// It automatically subscribes to MPRIS-related events and
+// `Poll` can be used to wait for any event.
+type Watcher struct {
+	*mpd.Watcher
+}
+
+var (
+	// See https://mpd.readthedocs.io/en/latest/protocol.html#command-idle
+	eventsToSubscribe = []string{
+		"playlist", // the queue (i.e. the current playlist) has been modified
+		"player",   // the player has been started, stopped or seeked or tags of the currently playing song have changed (e.g. received from stream)
+		"mixer",    // the volume has been changed
+		"options",  // options like repeat, random, crossfade, replay gain
+	}
+)
+
+// NewWatcher creates a new watcher with the given parameters.
+func NewWatcher(net, addr, passwd string) (*Watcher, error) {
+	w, err := mpd.NewWatcher(net, addr, passwd, eventsToSubscribe...)
+	if err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return &Watcher{w}, nil
+}
+
+// Poll waits for the next event, or errors out.
+func (w *Watcher) Poll(ctx context.Context) error {
+	select {
+	case <-w.Event:
+		return nil
+	case err := <-w.Error:
+		return errors.Wrap(err, "polling for events")
+	case <-ctx.Done():
+		return context.Canceled
+	}
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -23,11 +23,6 @@ with lib; let
       description = "Path to the file containing the password for the MPD server.";
       default = "";
     };
-    interval = mkOption {
-      type = types.str;
-      description = "The update interval to poll (in Go duration syntax, default to `1s`).";
-      default = "";
-    };
   };
 in
 {
@@ -71,7 +66,6 @@ in
               ExecStart = strings.concatStringsSep " "
                 [
                   "${cfg.package}/bin/mpd-mpris"
-                  (strings.optionalString (opts.interval != "") "-interval ${opts.interval}")
                   (strings.optionalString (opts.host != "") "-host ${opts.host}")
                   (strings.optionalString (opts.network != "") "-network ${opts.network}")
                   (strings.optionalString (opts.passwordFile != "") "-pwd-file ${opts.network}")

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -2,5 +2,5 @@
 buildGoModule {
   name = "mpd-mpris";
   src = ./..;
-  vendorSha256 = "sha256-GmdD/4VYp3KeblNGgltFWHdOnK5qsBa2ygIYOBrH+b0=";
+  vendorSha256 = "sha256-HCDJrp9WFB1z+FnYpOI5e/AojtdnpN2ZNtgGVaH/v/Q=";
 }

--- a/player.go
+++ b/player.go
@@ -149,7 +149,7 @@ func (s *Status) Update(p *Player) *dbus.Error {
 
 	// Volume
 	newVolume := math.Max(0, float64(status.Volume)/100.0)
-	if newVolume != s.Volume {
+	if math.Abs(newVolume-s.Volume) >= 0.5 {
 		s.Volume = newVolume
 		go p.setProp("org.mpris.MediaPlayer2.Player", "Volume", dbus.MakeVariant(newVolume))
 	}

--- a/player.go
+++ b/player.go
@@ -224,8 +224,7 @@ func (p *Player) OnShuffle(c *prop.Change) *dbus.Error {
 func (p *Player) createStatus(interval time.Duration) {
 	status, err := p.mpd.Status()
 	if err != nil {
-		log.Fatalf("%+v", err)
-		panic(err)
+		log.Fatalf("Cannot create status: %+v", err)
 	}
 	var playStatus PlaybackStatus
 	switch status.State {
@@ -247,7 +246,7 @@ func (p *Player) createStatus(interval time.Duration) {
 	}
 	song, err := p.mpd.CurrentSong()
 	if err != nil {
-		panic(err)
+		log.Fatalf("Cannot get current song: %+v", err)
 	}
 
 	volume := math.Max(0, float64(status.Volume)/100.0)


### PR DESCRIPTION
We basically use `mpd`'s `idle` command to wait for updates to fire our own `Status` update.

`-interval` is no longer needed, since we're not polling anymore.

Should resolve #24.