### PR TITLE
Use `Name` attribute as fallback

### DIFF
--- a/mpd/file.go
+++ b/mpd/file.go
@@ -59,7 +59,7 @@ func (c *Client) FileFromAttrs(attr mpd.Attrs) (s File, err error) {
 		s.Filepath = filepath.String()
 	}
 
-	if !p.String("Title", &s.Title, true) {
+	if !p.String("Title", &s.Title, true) && !p.String("Name", &s.Title, true) && !p.String("file", &s.Title, true) {
 		s.Title = "unknown title"
 	}
 	// All the following values can be empty


### PR DESCRIPTION
In some situations the `Title` attribute is missing (e.g. poorly configured internet radio stations).  In that case, we can fallback on the `Name` attribute and, if that fails, the `file` attribute.

`xesam:name` does not seem to be common[1], so using `Title` instead of adding a `Name` to the `File` struct.

[1] https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/