### PR TITLE
Improve logging around MPD keepalive failure

### DIFF
--- a/mpd/client.go
+++ b/mpd/client.go
@@ -217,7 +217,7 @@ func (c *Client) Keepalive(ctx context.Context) {
 			return
 		case <-ticker.C:
 			if err := c.Ping(); err != nil {
-				log.Fatalf("Connection to mpd is severed: %+v", errors.WithStack(err))
+				log.Fatalf("Connection to mpd is severed: %+v\nEnsure MPD's \"connection_timeout\" setting is greater than %v seconds.", errors.WithStack(err), timeout.Seconds())
 			}
 		}
 	}

--- a/mpd/client.go
+++ b/mpd/client.go
@@ -205,7 +205,7 @@ func (c *Client) Keepalive(ctx context.Context) {
 	if tStr, ok := os.LookupEnv("MPD_TIMEOUT"); ok {
 		if t, err := strconv.Atoi(tStr); err == nil {
 			timeout = time.Duration(t) * time.Second
-			log.Println("Using MPD_TIMEOUT's keepalive clock of %v", timeout)
+			log.Printf("Using MPD_TIMEOUT's keepalive clock of %v", timeout)
 		}
 	}
 


### PR DESCRIPTION
Per discussion in #39, this attempts to ease troubleshooting by adding a hint in the logs that the user should check their `connection_timeout` setting in MPD.

```
$ MPD_TIMEOUT=7 go run cmd/mpd-mpris/main.go
2023/07/28 13:10:57 command 'albumart' failed: No file exists
2023/07/28 13:10:57 mpd-mpris running
2023/07/28 13:10:57 Using MPD_TIMEOUT's keepalive clock of %v 7s
2023/07/28 13:11:04 Connection to mpd is severed: EOF
github.com/natsukagami/mpd-mpris/mpd.(*Client).Keepalive
	/home/justin/git/mpd-mpris/mpd/client.go:220
runtime.goexit
	/usr/lib/go/src/runtime/asm_amd64.s:1598
Ensure MPD's "connection_timeout" setting is greater than 7 seconds.
exit status 1
```