### PR TITLE
mpd-mpris.service: remove Requires=mpd.service

### DIFF
--- a/mpd-mpris.service
+++ b/mpd-mpris.service
@@ -1,6 +1,7 @@
 [Unit]
+# Requires=mpd.service is omitted because users may want to run mpd not as
+# a service but via terminal or network (remote mpd instance).
 Description=mpd-mpris: An implementation of the MPRIS protocol for MPD
-Requires=mpd.service
 After=mpd.service
 
 [Service]

--- a/mpd-mpris.service
+++ b/mpd-mpris.service
@@ -1,6 +1,7 @@
 [Unit]
-# Requires=mpd.service is omitted because users may want to run mpd not as
-# a service but via terminal or network (remote mpd instance).
+# If you run mpd-mpris to connect to a local mpd server, uncomment 
+# the following lines to declare a dependency with the mpd service.
+# Requires=mpd.service
 Description=mpd-mpris: An implementation of the MPRIS protocol for MPD
 After=mpd.service
 


### PR DESCRIPTION
Users may want to run mpd not as a service but via terminal or network (remote mpd instance). This same note is included in the file as a comment for info.