### PR TITLE
Allow setting unix/abstract sockets in MPD_HOST.

### DIFF
--- a/cmd/mpd-mpris/main.go
+++ b/cmd/mpd-mpris/main.go
@@ -94,6 +94,9 @@ func main() {
 			} else {
 				addr = env_host
 			}
+			if strings.HasPrefix(addr, "/") {
+				network = "unix"
+			}
 		}
 	}
 

--- a/cmd/mpd-mpris/main.go
+++ b/cmd/mpd-mpris/main.go
@@ -84,8 +84,10 @@ func main() {
 			addr = "localhost"
 			detectLocalSocket()
 		} else {
-			if strings.Index(env_host, "@") > -1 {
-				addr_pwd := strings.Split(env_host, "@")
+			// When looking for the password delimiter, ignore the first character.
+			// An '@' sign at the start of the envvar signifies an "abstract socket" without password.
+			if strings.Index(env_host[1:], "@") > -1 {
+				addr_pwd := strings.SplitN(env_host, "@", 2)
 				// allow providing an alternative password on the command line
 				if len(password) == 0 {
 					password = addr_pwd[0]
@@ -94,7 +96,8 @@ func main() {
 			} else {
 				addr = env_host
 			}
-			if strings.HasPrefix(addr, "/") {
+			// Check if addr refers to a path or abstract socket name and change network accordingly.
+			if strings.HasPrefix(addr, "/") || strings.HasPrefix(addr, "@") {
 				network = "unix"
 			}
 		}

--- a/cmd/mpd-mpris/main.go
+++ b/cmd/mpd-mpris/main.go
@@ -79,6 +79,8 @@ func main() {
 	flag.Parse()
 	password := getPassword()
 	if len(addr) == 0 {
+		// For a description of what can be in the the MPD_HOST environment variable, see:
+		// https://www.musicpd.org/doc/mpc/html/#cmdoption-host
 		env_host := os.Getenv("MPD_HOST")
 		if len(env_host) == 0 {
 			addr = "localhost"


### PR DESCRIPTION
The `MPD_HOST` environment variable, as understood by libmpdclient (used by mpc and many other clients) allows users to specify regular Unix domain sockets and also Linux "abstract" sockets, however mpd-mpris has no understanding of these and tries to resolve them as hostnames.

This commit adds a check to the code that handles the `MPD_HOST` environment variable, changing the network type to "unix" if it starts with a slash or at sign. Conveniently, the method of specifying abstract sockets in Go happens to be by using an at sign, so no further fiddling is needed.

It also adjusts the password handling code to ignore a leading at sign, as this signifies an abstract socket with no password, rather than an empty password.

With these changes, behaviour regarding `MPD_HOST` should be pretty much identical to libmpdclient.

Tested with Unix sockets, abstract sockets and abstract sockets with a password (specified like `MPD_HOST="password@@abstract-name"`, the same format mpc accepts)