### PR TITLE
Run OpenRC service in the background

### DIFF
--- a/services/mpd-mpris
+++ b/services/mpd-mpris
@@ -10,5 +10,5 @@ depend() {
 }
 
 start() {
-  $command $command_args
+  $command $command_args &
 }


### PR DESCRIPTION
Run the OpenRC service script in the background to stop it from preventing other services from starting. If the service is loaded on boot without moving it to the background, the user is unable to login.