### PR TITLE
Use type=dbus for systemd service

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -60,7 +60,7 @@ in
             };
 
             Service = {
-              Type = "simple";
+              Type = "dbus";
               Restart = "on-failure";
               RestartSec = "5s";
               ExecStart = strings.concatStringsSep " "

--- a/services/mpd-mpris.service
+++ b/services/mpd-mpris.service
@@ -8,6 +8,8 @@ After=mpd.service
 [Service]
 ExecStart=mpd-mpris -no-instance
 Restart=on-failure
+Type=dbus
+BusName=org.mpris.MediaPlayer2.mpd
 
 [Install]
 WantedBy=default.target


### PR DESCRIPTION
Some benefits listed here: https://www.man7.org/linux/man-pages/man5/systemd.service.5.html

Includes an implicit dependency on `dbus.service`, readiness check by bus exposure, etc.
