### PR TITLE
Fix song refresh when playing audio stream

### DIFF
--- a/mpd/client.go
+++ b/mpd/client.go
@@ -70,7 +70,10 @@ func (c *Client) CurrentSong() (Song, error) {
 	}
 	c.lastSongMu.Lock()
 	defer c.lastSongMu.Unlock()
-	if c.lastSong != nil && c.lastSong.Path() == a["file"] {
+
+	// Nasty hack: if duration is 0: we have an audio stream. The song can change,
+	// but its path won't. So we update anyways because we cannot be sure of the change!
+	if c.lastSong != nil && c.lastSong.Path() == a["file"] && c.lastSong.Duration > 0 {
 		// Heuristically, we have... the same song...
 		return *c.lastSong, nil
 	}

--- a/mpd/song.go
+++ b/mpd/song.go
@@ -48,7 +48,7 @@ func (s *Song) SameAs(other *Song) bool {
 	if other == nil || s == nil {
 		return s == nil && other == nil
 	}
-	return s.ID == other.ID && s.Path() == other.Path()
+	return s.ID == other.ID && s.Path() == other.Path() && s.Title == other.Title
 }
 
 // SongFromAttrs returns a song from the attributes map.


### PR DESCRIPTION
Hi,

Audio streams (e.g. web radios) are always the same file (i.e. the m3u file). However the song will change over time as sent by the stream.

We can't really know if the file is a stream or not, so we suppose it's a stream when the duration is 0.

Thanks!