### PR TITLE
Add DBus.Properties Interface to the Introspect method

### DIFF
--- a/introspect.go
+++ b/introspect.go
@@ -184,6 +184,81 @@ func (i *Instance) IntrospectNode() *introspect.Node {
 					},
 				},
 			},
+			introspect.Interface{
+				Name: "org.freedesktop.DBus.Properties",
+				Signals: []introspect.Signal{
+					introspect.Signal{
+						Name: "PropertiesChanged",
+						Args: []introspect.Arg{
+							introspect.Arg{
+								Name: "interface_name",
+								Type: "s",
+							},
+							introspect.Arg{
+								Name: "changed_properties",
+								Type: "a{sv}",
+							},
+						},
+					},
+				},
+				Methods: []introspect.Method{
+					introspect.Method{
+						Name: "Get",
+						Args: []introspect.Arg{
+							introspect.Arg{
+								Name:      "interface_name",
+								Type:      "s",
+								Direction: "in",
+							},
+							introspect.Arg{
+								Name:      "property_name",
+								Type:      "s",
+								Direction: "in",
+							},
+							introspect.Arg{
+								Name:      "value",
+								Type:      "v",
+								Direction: "out",
+							},
+						},
+					},
+					introspect.Method{
+						Name: "GetAll",
+						Args: []introspect.Arg{
+							introspect.Arg{
+								Name:      "interface_name",
+								Type:      "s",
+								Direction: "in",
+							},
+							introspect.Arg{
+								Name:      "properties",
+								Type:      "a{sv}",
+								Direction: "out",
+							},
+						},
+					},
+					introspect.Method{
+						Name: "Set",
+						Args: []introspect.Arg{
+							introspect.Arg{
+								Name:      "interface_name",
+								Type:      "s",
+								Direction: "in",
+							},
+							introspect.Arg{
+								Name:      "property_name",
+								Type:      "s",
+								Direction: "out",
+							},
+							introspect.Arg{
+								Name:      "value",
+								Type:      "v",
+								Direction: "in",
+							},
+						},
+					},
+				},
+			},
 			// TODO: This interface is not fully implemented.
 			// introspect.Interface{
 			// 	Name: "org.mpris.MediaPlayer2.TrackList",


### PR DESCRIPTION
Hello. I don't know much about DBus, so this was only tested insofar as getting the [lua_dbus_proxy](https://github.com/stefano-m/lua-dbus_proxy) library to generate a `proxy:Get()` method, which was not possible before this commit.  Thank you for making this program.