### PR TITLE
Do not feed MPD's position back to itself

### DIFF
--- a/player.go
+++ b/player.go
@@ -187,7 +187,7 @@ func (s *Status) Update(p *Player) *dbus.Error {
 	}
 
 	if s.Seek != status.Seek {
-		if s.Seek-status.Seek > seekTriggerMinimum || status.Seek-s.Seek > seekTriggerMinimum {
+		if absDuration(s.Seek-status.Seek) > seekTriggerMinimum {
 			go p.Seeked(UsFromDuration(status.Seek))
 		} else {
 			go p.setProp("org.mpris.MediaPlayer2.Player", "Position", dbus.MakeVariant(UsFromDuration(status.Seek)))
@@ -195,6 +195,15 @@ func (s *Status) Update(p *Player) *dbus.Error {
 		s.Seek = status.Seek
 	}
 	return nil
+}
+
+// Absolute value of a time.Duration.
+func absDuration(d time.Duration) time.Duration {
+	if d < 0 {
+		return -d
+	} else {
+		return d
+	}
 }
 
 func notImplemented(c *prop.Change) *dbus.Error {

--- a/player.go
+++ b/player.go
@@ -188,7 +188,7 @@ func (s *Status) Update(p *Player) *dbus.Error {
 
 	if s.Seek != status.Seek {
 		if s.Seek-status.Seek > seekTriggerMinimum || status.Seek-s.Seek > seekTriggerMinimum {
-			go p.SetPosition(TrackID(fmt.Sprintf(TrackIDFormat, status.Song)), UsFromDuration(status.Seek))
+			go p.Seeked(UsFromDuration(status.Seek))
 		} else {
 			go p.setProp("org.mpris.MediaPlayer2.Player", "Position", dbus.MakeVariant(UsFromDuration(status.Seek)))
 		}
@@ -450,5 +450,10 @@ func (p *Player) SetPosition(o TrackID, x TimeInUs) *dbus.Error {
 		return err
 	}
 	// Unnatural seek, create signal
+	return p.Seeked(x)
+}
+
+// Emit the Seeked DBus signal.
+func (p *Player) Seeked(x TimeInUs) *dbus.Error {
 	return p.transformErr(p.dbus.Emit("/org/mpris/MediaPlayer2", "org.mpris.MediaPlayer2.Player.Seeked", x))
 }


### PR DESCRIPTION
Fixes https://github.com/natsukagami/mpd-mpris/issues/75.

This is probably still wrong, but less obviously so: when detecting a seek from MPD, there is no reason to *tell* MPD about the seek, we can just emit a DBus signal.

Ideally a signal would not be emitted when changing tracks, but I leave this as future work.