### PR TITLE
bunch of artwork handling improvements

### DIFF
--- a/mpd/song.go
+++ b/mpd/song.go
@@ -13,19 +13,15 @@ import (
 
 var albumArtLock sync.Mutex
 var (
-	mpdTemp     string // Temp folder location
+	mpdTemp     = filepath.Join(os.TempDir(), "mpd_mpris") // Temp folder location
 	albumArtURI string
 )
 
-func init() {
-	mpdTemp = filepath.Join(os.TempDir(), "mpd_mpris")
+func newTempFile() string {
 	if err := os.MkdirAll(mpdTemp, 0777); err != nil {
 		log.Println("Cannot create temp file for album art, we don't support them then!", err)
-		return
+		return ""
 	}
-}
-
-func newTempFile() string {
 	f, err := ioutil.TempFile(mpdTemp, "artwork_")
 	if err != nil {
 		log.Println("Cannot create temp file for album art, we don't support them then!", err)
@@ -65,24 +61,31 @@ func (c *Client) SongFromAttrs(attr mpd.Attrs) (s Song, err error) {
 	albumArtLock.Lock()
 	defer albumArtLock.Unlock()
 
+	art, err := c.getAlbumArt(s.Path())
+	if err != nil {
+		log.Println(err)
+		return s, nil
+	}
+	if len(art) == 0 {
+		return s, nil
+	}
+
+	newAlbumArtURI := newTempFile()
+	if newAlbumArtURI == "" {
+		return s, nil
+	}
+	if err := ioutil.WriteFile(newAlbumArtURI, art, 0644); err != nil {
+		log.Println(err)
+		os.Remove(newAlbumArtURI)
+		return s, nil
+	}
+
 	if albumArtURI != "" {
 		// delete the old album art file
 		os.Remove(albumArtURI)
 	}
-	albumArtURI = newTempFile()
-	if albumArtURI != "" {
-		// Write the album art to it
-		art, err := c.getAlbumArt(s.Path())
-		if err != nil {
-			log.Println(err)
-			return s, nil
-		}
-		if err := ioutil.WriteFile(albumArtURI, art, 0x644); err != nil {
-			log.Println(err)
-			return s, nil
-		}
-		s.albumArt = true
-	}
+	albumArtURI = newAlbumArtURI
+	s.albumArt = true
 
 	return
 }

--- a/mpd/song.go
+++ b/mpd/song.go
@@ -1,6 +1,7 @@
 package mpd
 
 import (
+	"errors"
 	"io/ioutil"
 	"log"
 	"os"
@@ -31,6 +32,14 @@ func newTempFile() string {
 	return f.Name()
 }
 
+func clearAlbumArtURI() {
+	if albumArtURI != "" {
+		os.Remove(albumArtURI)
+		albumArtURI = ""
+	}
+	os.Remove(mpdTemp)
+}
+
 // Song represents a music file with metadata.
 type Song struct {
 	File
@@ -51,6 +60,9 @@ func (s *Song) SameAs(other *Song) bool {
 func (c *Client) SongFromAttrs(attr mpd.Attrs) (s Song, err error) {
 	if s.ID, err = strconv.Atoi(attr["Id"]); err != nil {
 		s.ID = -1
+		albumArtLock.Lock()
+		clearAlbumArtURI()
+		albumArtLock.Unlock()
 		return s, nil
 	}
 	if s.File, err = c.FileFromAttrs(attr); err != nil {
@@ -60,6 +72,11 @@ func (c *Client) SongFromAttrs(attr mpd.Attrs) (s Song, err error) {
 	// Attempt to load the album art.
 	albumArtLock.Lock()
 	defer albumArtLock.Unlock()
+	defer func() {
+		if !s.albumArt {
+			clearAlbumArtURI()
+		}
+	}()
 
 	art, err := c.getAlbumArt(s.Path())
 	if err != nil {
@@ -80,10 +97,7 @@ func (c *Client) SongFromAttrs(attr mpd.Attrs) (s Song, err error) {
 		return s, nil
 	}
 
-	if albumArtURI != "" {
-		// delete the old album art file
-		os.Remove(albumArtURI)
-	}
+	clearAlbumArtURI()
 	albumArtURI = newAlbumArtURI
 	s.albumArt = true
 
@@ -95,7 +109,20 @@ func (c *Client) getAlbumArt(uri string) ([]byte, error) {
 	if art, err := c.readPicture(uri); err == nil {
 		return art, nil
 	}
-	return c.AlbumArt(uri)
+
+	art, err := c.AlbumArt(uri)
+	if err == nil {
+		return art, nil
+	}
+	if isAlbumArtMissing(err) {
+		return nil, nil
+	}
+	return nil, err
+}
+
+func isAlbumArtMissing(err error) bool {
+	var mpdErr mpd.Error
+	return errors.As(err, &mpdErr) && mpdErr.Code == mpd.ErrorNoExist
 }
 
 // readPicture retrieves an album artwork image for a song with the given URI using MPD's readpicture command.

--- a/player.go
+++ b/player.go
@@ -125,8 +125,24 @@ func (p *Player) pollSeek(ctx context.Context) {
 // ============================================================================
 
 func (p *Player) setProp(iface, name string, value dbus.Variant) {
+	p.clearMetadataProp(iface, name)
 	if err := p.Instance.props.Set(iface, name, value); err != nil {
 		log.Printf("Setting %s %s failed: %+v\n", iface, name, errors.WithStack(err))
+	}
+}
+
+func (p *Player) clearMetadataProp(iface, name string) {
+	if iface != "org.mpris.MediaPlayer2.Player" || name != "Metadata" {
+		return
+	}
+
+	// godbus stores map updates into the existing map, leaving absent keys behind.
+	metadata, ok := p.Instance.props.GetMust(iface, name).(MetadataMap)
+	if !ok {
+		return
+	}
+	for key := range metadata {
+		delete(metadata, key)
 	}
 }
 


### PR DESCRIPTION
- treat MPD ErrorNoExist from albumart as a normal "no artwork" result, so tracks without covers do not spam the log
- stop eagerly creating /tmp/mpd_mpris at package init
- create /tmp/mpd_mpris and artwork_* only after MPD has returned non-empty artwork bytes
- avoid leaving zero-byte artwork_* files behind when the current track has no cover
- only update the internal artwork URI after the new artwork file has been written successfully
- remove a newly-created artwork temp file if writing the image fails
- clear artwork state when MPD reports no current track
- stop stale metadata keys like mpris:artUrl from surviving after switching to a track without artwork

fixes #81
